### PR TITLE
57449: SimpleSAMLphp compatability update MR master

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ At the moment, the logic allows to skip 2FA for normal users in the CE's LDAP,
 while enforcing 2FA for users considered "Group Administrators" or "Superusers".
 
 ```
-  $request['sspmod_linotp2_Auth_Process_OTP'] = [
+  $request[SimpleSAML\Module\CE2FA\Auth\Process\TwoFactorSkipProcessingFilter::OTP_SKIP_FLAG] = [
     'skip_check' => TRUE,
   ];
 ```

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.3",
-		"simplesamlphp/simplesamlphp": "~1.15-dev"
+		"simplesamlphp/simplesamlphp": "~1.17.7"
 	}
 }

--- a/lib/Auth/Ldap/Ldap.php
+++ b/lib/Auth/Ldap/Ldap.php
@@ -3,16 +3,16 @@
 namespace CE2FA\Auth\Ldap;
 
 use Exception;
-use SimpleSAML_Auth_LDAP;
-use SimpleSAML_Error_AuthSource;
-use SimpleSAML_Error_Exception;
-use SimpleSAML_Error_InvalidCredential;
-use SimpleSAML_Error_UserNotFound;
+use SimpleSAML\Auth\LDAP as SimpleSAMLLdap;
+use SimpleSAML\Error\AuthSource;
+use SimpleSAML\Error\Exception as SimpleSAMLException;
+use SimpleSAML\Error\InvalidCredential;
+use SimpleSAML\Error\UserNotFound;
 
 /**
  * Class Ldap
  */
-class Ldap extends SimpleSAML_Auth_LDAP {
+class Ldap extends SimpleSAMLLdap {
 
   protected $hostname;
 
@@ -73,7 +73,7 @@ class Ldap extends SimpleSAML_Auth_LDAP {
    * @param string $description
    * The exception's description
    *
-   * @return Exception
+   * @return \Exception
    */
   private function makeException($description, $type = NULL) {
     $errNo = 0x00;
@@ -98,15 +98,15 @@ class Ldap extends SimpleSAML_Auth_LDAP {
 
       switch ($type) {
         case ERR_INTERNAL:// 1 - ExInternal
-          return new SimpleSAML_Error_Exception($description, $errNo);
+          return new SimpleSAMLException($description, $errNo);
         case ERR_NO_USER:// 2 - ExUserNotFound
-          return new SimpleSAML_Error_UserNotFound($description, $errNo);
+          return new UserNotFound($description, $errNo);
         case ERR_WRONG_PW:// 3 - ExInvalidCredential
-          return new SimpleSAML_Error_InvalidCredential($description, $errNo);
+          return new InvalidCredential($description, $errNo);
         case ERR_AS_DATA_INCONSIST:// 4 - ExAsDataInconsist
-          return new SimpleSAML_Error_AuthSource('ldap', $description);
+          return new AuthSource('ldap', $description);
         case ERR_AS_INTERNAL:// 5 - ExAsInternal
-          return new SimpleSAML_Error_AuthSource('ldap', $description);
+          return new AuthSource('ldap', $description);
       }
     }
     else {
@@ -119,16 +119,16 @@ class Ldap extends SimpleSAML_Auth_LDAP {
       switch ($errNo) {
         case 0x20://LDAP_NO_SUCH_OBJECT
           $this->logger::warning($description);
-          return new SimpleSAML_Error_UserNotFound($description, $errNo);
+          return new UserNotFound($description, $errNo);
         case 0x31://LDAP_INVALID_CREDENTIALS
           $this->logger::info($description);
-          return new SimpleSAML_Error_InvalidCredential($description, $errNo);
+          return new InvalidCredential($description, $errNo);
         case -1://NO_SERVER_CONNECTION
           $this->logger::error($description);
-          return new SimpleSAML_Error_AuthSource('ldap', $description);
+          return new AuthSource('ldap', $description);
         default:
           $this->logger::error($description);
-          return new SimpleSAML_Error_AuthSource('ldap', $description);
+          return new AuthSource('ldap', $description);
       }
     }
   }

--- a/lib/Auth/Process/TwoFactorSkipProcessingFilter.php
+++ b/lib/Auth/Process/TwoFactorSkipProcessingFilter.php
@@ -16,6 +16,8 @@ class TwoFactorSkipProcessingFilter extends SimpleSAML_Auth_ProcessingFilter {
 
   const AdminGroupSuffix = 'Admins';
 
+  const OTP_SKIP_FLAG = 'sspmod_linotp2_Auth_Process_OTP';
+
   /**
    * @var \CE2FA\Auth\Ldap\Ldap
    */
@@ -85,7 +87,7 @@ class TwoFactorSkipProcessingFilter extends SimpleSAML_Auth_ProcessingFilter {
       $username = $ldap_attributes['uid'];
 
       if ($this->userRequires2FA($username, $ldap_attributes) === FALSE) {
-        $request['sspmod_linotp2_Auth_Process_OTP'] = [
+        $request[self::OTP_SKIP_FLAG] = [
           'skip_check' => TRUE,
         ];
       }

--- a/lib/Auth/Process/TwoFactorSkipProcessingFilter.php
+++ b/lib/Auth/Process/TwoFactorSkipProcessingFilter.php
@@ -4,7 +4,7 @@ namespace SimpleSAML\Module\CE2FA\Auth\Process;
 
 use CE2FA\Auth\Ldap\Ldap;
 use SimpleSAML\Logger;
-use SimpleSAML_Auth_ProcessingFilter;
+use SimpleSAML\Auth\ProcessingFilter;
 
 /**
  * Filter to manipulate request in order to enforce the user to pass 2fa.
@@ -12,7 +12,7 @@ use SimpleSAML_Auth_ProcessingFilter;
  * @author Salvador Molina <salva.momo@gmail.com>
  * @package SimpleSAMLphp
  */
-class TwoFactorSkipProcessingFilter extends SimpleSAML_Auth_ProcessingFilter {
+class TwoFactorSkipProcessingFilter extends ProcessingFilter {
 
   const AdminGroupSuffix = 'Admins';
 

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+$config = [
+    'configuration' => 'some value',
+];

--- a/tests/src/Auth/Process/TwoFactorSkipProcessingFilterTest.php
+++ b/tests/src/Auth/Process/TwoFactorSkipProcessingFilterTest.php
@@ -164,6 +164,9 @@ class TwoFactorSkipProcessingFilterTest extends TestCase {
    * @test
    */
   public function testProcessSetsRightFlagInRequestArray() {
+    // Set the configuration environment variable to point to a test config file.
+    putenv("SIMPLESAMLPHP_CONFIG_DIR=./tests/config/");
+
     $filter = new TwoFactorSkipProcessingFilter([], NULL);
     $ldap = Ldap::fromConfigArray(['ldap.hostname' => 'dummy'], new SpyLogger());
     $filter->setLdap($ldap);
@@ -173,7 +176,7 @@ class TwoFactorSkipProcessingFilterTest extends TestCase {
       'Attributes' => ['uid' => 'someuid', 'employeeType' => 'non-superuser']
     ];
     $filter->process($request_normal_u);
-    $this->assertTrue($request_normal_u['OTP']['skip_check'], 'linotp2 key correctly set for normal user.');
+    $this->assertTrue($request_normal_u[TwoFactorSkipProcessingFilter::OTP_SKIP_FLAG]['skip_check'], 'linotp2 key correctly set for normal user.');
 
     $request_superuser = [
       'Attributes' => ['uid' => 'someuid', 'employeeType' => 'superuser']

--- a/tests/src/Auth/Process/TwoFactorSkipProcessingFilterTest.php
+++ b/tests/src/Auth/Process/TwoFactorSkipProcessingFilterTest.php
@@ -173,13 +173,13 @@ class TwoFactorSkipProcessingFilterTest extends TestCase {
       'Attributes' => ['uid' => 'someuid', 'employeeType' => 'non-superuser']
     ];
     $filter->process($request_normal_u);
-    $this->assertTrue($request_normal_u['sspmod_linotp2_Auth_Process_OTP']['skip_check'], 'linotp2 key correctly set for normal user.');
+    $this->assertTrue($request_normal_u['OTP']['skip_check'], 'linotp2 key correctly set for normal user.');
 
     $request_superuser = [
       'Attributes' => ['uid' => 'someuid', 'employeeType' => 'superuser']
     ];
     $filter->process($request_superuser);
-    $this->assertArrayNotHasKey('sspmod_linotp2_Auth_Process_OTP', $request_superuser, 'linotp2 key not set for superuser.');
+    $this->assertArrayNotHasKey(TwoFactorSkipProcessingFilter::OTP_SKIP_FLAG, $request_superuser, 'linotp2 key not set for superuser.');
   }
 
 }


### PR DESCRIPTION
- Updated class names to point to the new (namespaced) locations in SimpleSAMLphp.
- Used a constant to detect this module being triggered of relying on a string to detect the linotp2 flag instead of a hardcoded string.
- Ensured unit tests run and pass correctly.